### PR TITLE
Update reflect.go

### DIFF
--- a/cmd/cloud_login.go
+++ b/cmd/cloud_login.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"syscall"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+	"gopkg.in/guregu/null.v3"
+
+	"go.k6.io/k6/cloudapi"
+	"go.k6.io/k6/cmd/state"
+	"go.k6.io/k6/lib/consts"
+	"go.k6.io/k6/ui"
+)
+
+const cloudLoginCommandName = "login"
+
+type cmdCloudLogin struct {
+	globalState *state.GlobalState
+}
+
+func getCmdCloudLogin(gs *state.GlobalState) *cobra.Command {
+	c := &cmdCloudLogin{
+		globalState: gs,
+	}
+
+	// loginCloudCommand represents the 'cloud login' command
+	exampleText := getExampleText(gs, `
+  # Log in with an email/password
+  {{.}} cloud login
+
+  # Store a token in k6's persistent configuration
+  {{.}} cloud login -t <YOUR_TOKEN>
+
+  # Display the stored token
+  {{.}} cloud login -s
+  
+  # Reset the stored token
+  {{.}} cloud login -r`[1:])
+
+	loginCloudCommand := &cobra.Command{
+		Use:   cloudLoginCommandName,
+		Short: "Authenticate with Grafana Cloud k6",
+		Long: `Authenticate with Grafana Cloud k6.
+
+This command will authenticate you with Grafana Cloud k6.
+Once authenticated you can start running tests in the cloud by using the "k6 cloud run"
+command, or by executing a test locally and outputting samples to the cloud using
+the "k6 run -o cloud" command.
+`,
+		Example: exampleText,
+		Args:    cobra.NoArgs,
+		RunE:    c.run,
+	}
+
+	loginCloudCommand.Flags().StringP("token", "t", "", "specify `token` to use")
+	loginCloudCommand.Flags().BoolP("show", "s", false, "display saved token and exit")
+	loginCloudCommand.Flags().BoolP("reset", "r", false, "reset stored token")
+
+	return loginCloudCommand
+}
+
+// run is the code that runs when the user executes `k6 cloud login`
+//
+//nolint:funlen
+func (c *cmdCloudLogin) run(cmd *cobra.Command, _ []string) error {
+	currentDiskConf, err := readDiskConfig(c.globalState)
+	if err != nil {
+		return err
+	}
+
+	currentJSONConfig := cloudapi.Config{}
+	currentJSONConfigRaw := currentDiskConf.Collectors["cloud"]
+	if currentJSONConfigRaw != nil {
+		// We only want to modify this config, see comment below
+		if jsonerr := json.Unmarshal(currentJSONConfigRaw, &currentJSONConfig); jsonerr != nil {
+			return jsonerr
+		}
+	}
+
+	// We want to use this fully consolidated config for things like
+	// host addresses, so users can overwrite them with env vars.
+	consolidatedCurrentConfig, warn, err := cloudapi.GetConsolidatedConfig(
+		currentJSONConfigRaw, c.globalState.Env, "", nil, nil)
+	if err != nil {
+		return err
+	}
+
+	if warn != "" {
+		c.globalState.Logger.Warn(warn)
+	}
+
+	// But we don't want to save them back to the JSON file, we only
+	// want to save what already existed there and the login details.
+	newCloudConf := currentJSONConfig
+
+	show := getNullBool(cmd.Flags(), "show")
+	reset := getNullBool(cmd.Flags(), "reset")
+	token := getNullString(cmd.Flags(), "token")
+	switch {
+	case reset.Valid:
+		newCloudConf.Token = null.StringFromPtr(nil)
+		printToStdout(c.globalState, "  token reset\n")
+	case show.Bool:
+	case token.Valid:
+		newCloudConf.Token = token
+	default:
+		form := ui.Form{
+			Banner: "Please enter your Grafana Cloud k6 credentials",
+			Fields: []ui.Field{
+				ui.StringField{
+					Key:   "Email",
+					Label: "Email",
+				},
+				ui.PasswordField{
+					Key:   "Password",
+					Label: "Password",
+				},
+			},
+		}
+		if !term.IsTerminal(int(syscall.Stdin)) { //nolint:unconvert
+			c.globalState.Logger.Warn("Stdin is not a terminal, falling back to plain text input")
+		}
+		var vals map[string]string
+		vals, err = form.Run(c.globalState.Stdin, c.globalState.Stdout)
+		if err != nil {
+			return err
+		}
+		email := vals["Email"]
+		password := vals["Password"]
+
+		client := cloudapi.NewClient(
+			c.globalState.Logger,
+			"",
+			consolidatedCurrentConfig.Host.String,
+			consts.Version,
+			consolidatedCurrentConfig.Timeout.TimeDuration())
+
+		var res *cloudapi.LoginResponse
+		res, err = client.Login(email, password)
+		if err != nil {
+			return err
+		}
+
+		if res.Token == "" {
+			return errors.New("your account does not appear to have an active API token, please consult the " +
+				"Grafana Cloud k6 documentation for instructions on how to generate " +
+				"one: https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication")
+		}
+
+		newCloudConf.Token = null.StringFrom(res.Token)
+	}
+
+	if currentDiskConf.Collectors == nil {
+		currentDiskConf.Collectors = make(map[string]json.RawMessage)
+	}
+	currentDiskConf.Collectors["cloud"], err = json.Marshal(newCloudConf)
+	if err != nil {
+		return err
+	}
+	if err := writeDiskConfig(c.globalState, currentDiskConf); err != nil {
+		return err
+	}
+
+	if newCloudConf.Token.Valid {
+		valueColor := getColor(c.globalState.Flags.NoColor || !c.globalState.Stdout.IsTTY, color.FgCyan)
+		if !c.globalState.Flags.Quiet {
+			printToStdout(c.globalState, fmt.Sprintf("  token: %s\n", valueColor.Sprint(newCloudConf.Token.String)))
+		}
+		printToStdout(c.globalState, fmt.Sprintf(
+			"Logged in successfully, token saved in %s\n", c.globalState.Flags.ConfigFilePath,
+		))
+	}
+	return nil
+}

--- a/cmd/cloud_run.go
+++ b/cmd/cloud_run.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"go.k6.io/k6/cmd/state"
+)
+
+const cloudRunCommandName string = "run"
+
+func getCmdCloudRun(gs *state.GlobalState) *cobra.Command {
+	deprecatedCloudCmd := &cmdCloud{
+		gs:            gs,
+		showCloudLogs: true,
+		exitOnRunning: false,
+		uploadOnly:    false,
+	}
+
+	exampleText := getExampleText(gs, `
+  # Run a test script in Grafana Cloud k6
+  $ {{.}} cloud run script.js
+
+  # Run a test archive in Grafana Cloud k6
+  $ {{.}} cloud run archive.tar
+
+  # Read a test script or archive from stdin and run it in Grafana Cloud k6
+  $ {{.}} cloud run - < script.js`[1:])
+
+	cloudRunCmd := &cobra.Command{
+		Use:   cloudRunCommandName,
+		Short: "Run a test in Grafana Cloud k6",
+		Long: `Run a test in Grafana Cloud k6.
+
+This will archive test script(s), including all necessary resources, and execute the test in the Grafana Cloud k6
+service. Using this command requires to be authenticated against Grafana Cloud k6.
+Use the "k6 cloud login" command to authenticate.`,
+		Example: exampleText,
+		Args: exactArgsWithMsg(1,
+			"the k6 cloud run command expects a single argument consisting in either a path to a script or "+
+				"archive file, or the \"-\" symbol indicating the script or archive should be read from stdin",
+		),
+		PreRunE: deprecatedCloudCmd.preRun,
+		RunE:    deprecatedCloudCmd.run,
+	}
+
+	cloudRunCmd.Flags().SortFlags = false
+	cloudRunCmd.Flags().AddFlagSet(deprecatedCloudCmd.flagSet())
+
+	return cloudRunCmd
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -16,6 +16,8 @@ func getCmdLogin(gs *state.GlobalState) *cobra.Command {
 Logging into a service changes the default when just "-o [type]" is passed with
 no parameters, you can always override the stored credentials by passing some
 on the commandline.`,
+		Deprecated: `and will be removed in a future release. Please use the "k6 cloud login" command instead.
+`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Usage()
 		},

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -33,11 +33,14 @@ func getCmdLoginCloud(gs *state.GlobalState) *cobra.Command {
 	loginCloudCommand := &cobra.Command{
 		Use:   "cloud",
 		Short: "Authenticate with k6 Cloud",
-		Long: `Authenticate with k6 Cloud",
+		Long: `Authenticate with Grafana Cloud k6.
 
 This will set the default token used when just "k6 run -o cloud" is passed.`,
 		Example: exampleText,
 		Args:    cobra.NoArgs,
+		Deprecated: `and will be removed in a future release.
+Please use the "k6 cloud login" command instead.
+`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			currentDiskConf, err := readDiskConfig(gs)
 			if err != nil {

--- a/cmd/tests/cmd_cloud_run_test.go
+++ b/cmd/tests/cmd_cloud_run_test.go
@@ -1,0 +1,12 @@
+package tests
+
+import "testing"
+
+func TestK6CloudRun(t *testing.T) {
+	t.Parallel()
+	runCloudTests(t, setupK6CloudRunCmd)
+}
+
+func setupK6CloudRunCmd(cliFlags []string) []string {
+	return append([]string{"k6", "cloud", "run"}, append(cliFlags, "test.js")...)
+}

--- a/cmd/tests/cmd_cloud_test.go
+++ b/cmd/tests/cmd_cloud_test.go
@@ -10,13 +10,233 @@ import (
 	"path/filepath"
 	"testing"
 
+	"go.k6.io/k6/lib/testutils"
+
+	"go.k6.io/k6/cmd"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/cloudapi"
-	"go.k6.io/k6/cmd"
 	"go.k6.io/k6/lib/fsext"
-	"go.k6.io/k6/lib/testutils"
 )
+
+func TestK6Cloud(t *testing.T) {
+	t.Parallel()
+	runCloudTests(t, setupK6CloudCmd)
+}
+
+func setupK6CloudCmd(cliFlags []string) []string {
+	return append([]string{"k6", "cloud"}, append(cliFlags, "test.js")...)
+}
+
+type setupCommandFunc func(cliFlags []string) []string
+
+func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
+	t.Run("TestCloudNotLoggedIn", func(t *testing.T) {
+		t.Parallel()
+
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil, nil)
+		delete(ts.Env, "K6_CLOUD_TOKEN")
+		ts.ExpectedExitCode = -1 // TODO: use a more specific exit code?
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `not logged in`)
+	})
+
+	t.Run("TestCloudLoggedInWithScriptToken", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		export let options = {
+			ext: {
+				loadimpact: {
+					token: "asdf",
+					name: "my load test",
+					projectID: 124,
+					note: 124,
+				},
+			}
+		};
+		export default function() {};
+	`
+
+		ts := getSimpleCloudTestState(t, []byte(script), setupCmd, nil, nil, nil)
+		delete(ts.Env, "K6_CLOUD_TOKEN")
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.NotContains(t, stdout, `not logged in`)
+		assert.Contains(t, stdout, `execution: cloud`)
+		assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+		assert.Contains(t, stdout, `test status: Finished`)
+	})
+
+	t.Run("TestCloudExitOnRunning", func(t *testing.T) {
+		t.Parallel()
+
+		cs := func() cloudapi.TestProgressResponse {
+			return cloudapi.TestProgressResponse{
+				RunStatusText: "Running",
+				RunStatus:     cloudapi.RunStatusRunning,
+			}
+		}
+
+		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"}, nil, cs)
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `execution: cloud`)
+		assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+		assert.Contains(t, stdout, `test status: Running`)
+	})
+
+	t.Run("TestCloudUploadOnly", func(t *testing.T) {
+		t.Parallel()
+
+		cs := func() cloudapi.TestProgressResponse {
+			return cloudapi.TestProgressResponse{
+				RunStatusText: "Archived",
+				RunStatus:     cloudapi.RunStatusArchived,
+			}
+		}
+
+		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--upload-only", "--log-output=stdout"}, nil, cs)
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `execution: cloud`)
+		assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+		assert.Contains(t, stdout, `test status: Archived`)
+	})
+
+	t.Run("TestCloudWithConfigOverride", func(t *testing.T) {
+		t.Parallel()
+
+		configOverride := http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+			resp.WriteHeader(http.StatusOK)
+			_, err := fmt.Fprint(resp, `{
+			"reference_id": "123",
+			"config": {
+				"webAppURL": "https://bogus.url",
+				"testRunDetails": "something from the cloud"
+			},
+			"logs": [
+				{"level": "invalid", "message": "test debug message"},
+				{"level": "warning", "message": "test warning"},
+				{"level": "error", "message": "test error"}
+			]
+		}`)
+			assert.NoError(t, err)
+		})
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, configOverride, nil)
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, "execution: cloud")
+		assert.Contains(t, stdout, "output: something from the cloud")
+		assert.Contains(t, stdout, `level=debug msg="invalid message level 'invalid' for message 'test debug message'`)
+		assert.Contains(t, stdout, `level=error msg="test debug message" source=grafana-k6-cloud`)
+		assert.Contains(t, stdout, `level=warning msg="test warning" source=grafana-k6-cloud`)
+		assert.Contains(t, stdout, `level=error msg="test error" source=grafana-k6-cloud`)
+	})
+
+	// TestCloudWithArchive tests that if k6 uses a static archive with the script inside that has cloud options like:
+	//
+	//	export let options = {
+	//		ext: {
+	//			loadimpact: {
+	//				name: "my load test",
+	//				projectID: 124,
+	//				note: "lorem ipsum",
+	//			},
+	//		}
+	//	};
+	//
+	// actually sends to the cloud the archive with the correct metadata (metadata.json), like:
+	//
+	//	"ext": {
+	//		"loadimpact": {
+	//	        "name": "my load test",
+	//	        "note": "lorem ipsum",
+	//	        "projectID": 124
+	//	      }
+	//	}
+	t.Run("TestCloudWithArchive", func(t *testing.T) {
+		t.Parallel()
+
+		testRunID := 123
+		ts := NewGlobalTestState(t)
+
+		archiveUpload := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+			// check the archive
+			file, _, err := req.FormFile("file")
+			assert.NoError(t, err)
+			assert.NotNil(t, file)
+
+			// temporary write the archive for file system
+			data, err := io.ReadAll(file)
+			assert.NoError(t, err)
+
+			tmpPath := filepath.Join(ts.Cwd, "archive_to_cloud.tar")
+			require.NoError(t, fsext.WriteFile(ts.FS, tmpPath, data, 0o644))
+
+			// check what inside
+			require.NoError(t, testutils.Untar(t, ts.FS, tmpPath, "tmp/"))
+
+			metadataRaw, err := fsext.ReadFile(ts.FS, "tmp/metadata.json")
+			require.NoError(t, err)
+
+			metadata := struct {
+				Options struct {
+					Cloud struct {
+						Name      string `json:"name"`
+						Note      string `json:"note"`
+						ProjectID int    `json:"projectID"`
+					} `json:"cloud"`
+				} `json:"options"`
+			}{}
+
+			// then unpacked metadata should not contain any environment variables passed at the moment of archive creation
+			require.NoError(t, json.Unmarshal(metadataRaw, &metadata))
+			require.Equal(t, "my load test", metadata.Options.Cloud.Name)
+			require.Equal(t, "lorem ipsum", metadata.Options.Cloud.Note)
+			require.Equal(t, 124, metadata.Options.Cloud.ProjectID)
+
+			// respond with the test run ID
+			resp.WriteHeader(http.StatusOK)
+			_, err = fmt.Fprintf(resp, `{"reference_id": "%d"}`, testRunID)
+			assert.NoError(t, err)
+		})
+
+		srv := getMockCloud(t, testRunID, archiveUpload, nil)
+
+		data, err := os.ReadFile(filepath.Join("testdata/archives", "archive_v0.46.0_with_loadimpact_option.tar")) //nolint:forbidigo // it's a test
+		require.NoError(t, err)
+
+		require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "archive.tar"), data, 0o644))
+
+		ts.CmdArgs = []string{"k6", "cloud", "--verbose", "--log-output=stdout", "archive.tar"}
+		ts.Env["K6_SHOW_CLOUD_LOGS"] = "false" // no mock for the logs yet
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+		ts.Env["K6_CLOUD_TOKEN"] = "foo" // doesn't matter, we mock the cloud
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.NotContains(t, stdout, `not logged in`)
+		assert.Contains(t, stdout, `execution: cloud`)
+		assert.Contains(t, stdout, `hello world from archive`)
+		assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+		assert.Contains(t, stdout, `test status: Finished`)
+	})
+}
 
 func cloudTestStartSimple(tb testing.TB, testRunID int) http.Handler {
 	return http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
@@ -60,10 +280,7 @@ func getMockCloud(
 	return srv
 }
 
-func getSimpleCloudTestState(
-	t *testing.T, script []byte, cliFlags []string,
-	archiveUpload http.Handler, progressCallback func() cloudapi.TestProgressResponse,
-) *GlobalTestState {
+func getSimpleCloudTestState(t *testing.T, script []byte, setupCmd setupCommandFunc, cliFlags []string, archiveUpload http.Handler, progressCallback func() cloudapi.TestProgressResponse) *GlobalTestState {
 	if script == nil {
 		script = []byte(`export default function() {}`)
 	}
@@ -76,215 +293,10 @@ func getSimpleCloudTestState(
 
 	ts := NewGlobalTestState(t)
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.js"), script, 0o644))
-	ts.CmdArgs = append(append([]string{"k6", "cloud"}, cliFlags...), "test.js")
+	ts.CmdArgs = setupCmd(cliFlags)
 	ts.Env["K6_SHOW_CLOUD_LOGS"] = "false" // no mock for the logs yet
 	ts.Env["K6_CLOUD_HOST"] = srv.URL
 	ts.Env["K6_CLOUD_TOKEN"] = "foo" // doesn't matter, we mock the cloud
 
 	return ts
-}
-
-func TestCloudNotLoggedIn(t *testing.T) {
-	t.Parallel()
-
-	ts := getSimpleCloudTestState(t, nil, nil, nil, nil)
-	delete(ts.Env, "K6_CLOUD_TOKEN")
-	ts.ExpectedExitCode = -1 // TODO: use a more specific exit code?
-	cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-	stdout := ts.Stdout.String()
-	t.Log(stdout)
-	assert.Contains(t, stdout, `Not logged in`)
-}
-
-func TestCloudLoggedInWithScriptToken(t *testing.T) {
-	t.Parallel()
-
-	script := `
-		export let options = {
-			ext: {
-				loadimpact: {
-					token: "asdf",
-					name: "my load test",
-					projectID: 124,
-					note: 124,
-				},
-			}
-		};
-		export default function() {};
-	`
-
-	ts := getSimpleCloudTestState(t, []byte(script), nil, nil, nil)
-	delete(ts.Env, "K6_CLOUD_TOKEN")
-	cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-	stdout := ts.Stdout.String()
-	t.Log(stdout)
-	assert.NotContains(t, stdout, `Not logged in`)
-	assert.Contains(t, stdout, `execution: cloud`)
-	assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
-	assert.Contains(t, stdout, `test status: Finished`)
-}
-
-func TestCloudExitOnRunning(t *testing.T) {
-	t.Parallel()
-
-	cs := func() cloudapi.TestProgressResponse {
-		return cloudapi.TestProgressResponse{
-			RunStatusText: "Running",
-			RunStatus:     cloudapi.RunStatusRunning,
-		}
-	}
-
-	ts := getSimpleCloudTestState(t, nil, []string{"--exit-on-running", "--log-output=stdout"}, nil, cs)
-	cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-	stdout := ts.Stdout.String()
-	t.Log(stdout)
-	assert.Contains(t, stdout, `execution: cloud`)
-	assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
-	assert.Contains(t, stdout, `test status: Running`)
-}
-
-func TestCloudUploadOnly(t *testing.T) {
-	t.Parallel()
-
-	cs := func() cloudapi.TestProgressResponse {
-		return cloudapi.TestProgressResponse{
-			RunStatusText: "Archived",
-			RunStatus:     cloudapi.RunStatusArchived,
-		}
-	}
-
-	ts := getSimpleCloudTestState(t, nil, []string{"--upload-only", "--log-output=stdout"}, nil, cs)
-	cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-	stdout := ts.Stdout.String()
-	t.Log(stdout)
-	assert.Contains(t, stdout, `execution: cloud`)
-	assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
-	assert.Contains(t, stdout, `test status: Archived`)
-}
-
-func TestCloudWithConfigOverride(t *testing.T) {
-	t.Parallel()
-
-	configOverride := http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
-		resp.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprint(resp, `{
-			"reference_id": "123",
-			"config": {
-				"webAppURL": "https://bogus.url",
-				"testRunDetails": "something from the cloud"
-			},
-			"logs": [
-				{"level": "invalid", "message": "test debug message"},
-				{"level": "warning", "message": "test warning"},
-				{"level": "error", "message": "test error"}
-			]
-		}`)
-		assert.NoError(t, err)
-	})
-	ts := getSimpleCloudTestState(t, nil, nil, configOverride, nil)
-	cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-	stdout := ts.Stdout.String()
-	t.Log(stdout)
-	assert.Contains(t, stdout, "execution: cloud")
-	assert.Contains(t, stdout, "output: something from the cloud")
-	assert.Contains(t, stdout, `level=debug msg="invalid message level 'invalid' for message 'test debug message'`)
-	assert.Contains(t, stdout, `level=error msg="test debug message" source=grafana-k6-cloud`)
-	assert.Contains(t, stdout, `level=warning msg="test warning" source=grafana-k6-cloud`)
-	assert.Contains(t, stdout, `level=error msg="test error" source=grafana-k6-cloud`)
-}
-
-// TestCloudWithArchive tests that if k6 uses a static archive with the script inside that has cloud options like:
-//
-//	export let options = {
-//		ext: {
-//			loadimpact: {
-//				name: "my load test",
-//				projectID: 124,
-//				note: "lorem ipsum",
-//			},
-//		}
-//	};
-//
-// actually sends to the cloud the archive with the correct metadata (metadata.json), like:
-//
-//	"ext": {
-//		"loadimpact": {
-//	        "name": "my load test",
-//	        "note": "lorem ipsum",
-//	        "projectID": 124
-//	      }
-//	}
-func TestCloudWithArchive(t *testing.T) {
-	t.Parallel()
-
-	testRunID := 123
-	ts := NewGlobalTestState(t)
-
-	archiveUpload := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-		// check the archive
-		file, _, err := req.FormFile("file")
-		assert.NoError(t, err)
-		assert.NotNil(t, file)
-
-		// temporary write the archive for file system
-		data, err := io.ReadAll(file)
-		assert.NoError(t, err)
-
-		tmpPath := filepath.Join(ts.Cwd, "archive_to_cloud.tar")
-		require.NoError(t, fsext.WriteFile(ts.FS, tmpPath, data, 0o644))
-
-		// check what inside
-		require.NoError(t, testutils.Untar(t, ts.FS, tmpPath, "tmp/"))
-
-		metadataRaw, err := fsext.ReadFile(ts.FS, "tmp/metadata.json")
-		require.NoError(t, err)
-
-		metadata := struct {
-			Options struct {
-				Cloud struct {
-					Name      string `json:"name"`
-					Note      string `json:"note"`
-					ProjectID int    `json:"projectID"`
-				} `json:"cloud"`
-			} `json:"options"`
-		}{}
-
-		// then unpacked metadata should not contain any environment variables passed at the moment of archive creation
-		require.NoError(t, json.Unmarshal(metadataRaw, &metadata))
-		require.Equal(t, "my load test", metadata.Options.Cloud.Name)
-		require.Equal(t, "lorem ipsum", metadata.Options.Cloud.Note)
-		require.Equal(t, 124, metadata.Options.Cloud.ProjectID)
-
-		// respond with the test run ID
-		resp.WriteHeader(http.StatusOK)
-		_, err = fmt.Fprintf(resp, `{"reference_id": "%d"}`, testRunID)
-		assert.NoError(t, err)
-	})
-
-	srv := getMockCloud(t, testRunID, archiveUpload, nil)
-
-	data, err := os.ReadFile(filepath.Join("testdata/archives", "archive_v0.46.0_with_loadimpact_option.tar")) //nolint:forbidigo // it's a test
-	require.NoError(t, err)
-
-	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "archive.tar"), data, 0o644))
-
-	ts.CmdArgs = []string{"k6", "cloud", "--verbose", "--log-output=stdout", "archive.tar"}
-	ts.Env["K6_SHOW_CLOUD_LOGS"] = "false" // no mock for the logs yet
-	ts.Env["K6_CLOUD_HOST"] = srv.URL
-	ts.Env["K6_CLOUD_TOKEN"] = "foo" // doesn't matter, we mock the cloud
-
-	cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-	stdout := ts.Stdout.String()
-	t.Log(stdout)
-	assert.NotContains(t, stdout, `Not logged in`)
-	assert.Contains(t, stdout, `execution: cloud`)
-	assert.Contains(t, stdout, `hello world from archive`)
-	assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
-	assert.Contains(t, stdout, `test status: Finished`)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible
 	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/websocket v1.5.1
-	github.com/grafana/xk6-browser v1.6.1-0.20240701105714-29f6ef3049fe
+	github.com/grafana/xk6-browser v1.7.0
 	github.com/grafana/xk6-dashboard v0.7.5
 	github.com/grafana/xk6-output-opentelemetry v0.1.1
 	github.com/grafana/xk6-output-prometheus-remote v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/grafana/sobek v0.0.0-20240711133011-3a280d337ef4 h1:SKC348XXnCe9EIsAJ+xs5lzlZbzRsrGkqVbJ3451p3k=
 github.com/grafana/sobek v0.0.0-20240711133011-3a280d337ef4/go.mod h1:tUEHKWaMrxFGrMgjeAH85OEceCGQiSl6a/6Wckj/Vf4=
-github.com/grafana/xk6-browser v1.6.1-0.20240701105714-29f6ef3049fe h1:uE7e1Lzris7YuM5mRLulkUGBIL9WmPHvLrA2RyZLyy8=
-github.com/grafana/xk6-browser v1.6.1-0.20240701105714-29f6ef3049fe/go.mod h1:TNngUsbmV3I5NDVklGxjpAR2znEjYEsBtHQirGw8nAI=
+github.com/grafana/xk6-browser v1.7.0 h1:Rip0st43EmzV37DFO2Gt7sXO4TTRM4g9wGMwBvVb67c=
+github.com/grafana/xk6-browser v1.7.0/go.mod h1:TNngUsbmV3I5NDVklGxjpAR2znEjYEsBtHQirGw8nAI=
 github.com/grafana/xk6-dashboard v0.7.5 h1:TcILyffT/Ea/XD7xG1jMA5lwtusOPRbEQsQDHmO30Mk=
 github.com/grafana/xk6-dashboard v0.7.5/go.mod h1:Y75F8xmgCraKT+pBzFH6me9AyH5PkXD+Bxo1dm6Il/M=
 github.com/grafana/xk6-output-opentelemetry v0.1.1 h1:kLfzKkL9olhmMO+Kmr7ObhX3LknSAbUbzFaDG6mQVeg=

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -2115,6 +2115,7 @@ func TestRequestAndBatchTLS(t *testing.T) {
 			default:
 				panic(versionTest.Name + " unsupported")
 			}
+			s.TLS.MinVersion = tls.VersionTLS10
 			go func() {
 				_ = s.Config.Serve(s.Listener)
 			}()

--- a/lib/netext/grpcext/reflect.go
+++ b/lib/netext/grpcext/reflect.go
@@ -19,6 +19,7 @@ type reflectionClient struct {
 // It is called in the connect function the first time the Client.Connect function is called.
 func (rc *reflectionClient) Reflect(ctx context.Context) (*descriptorpb.FileDescriptorSet, error) {
 	client := grpcreflect.NewClientAuto(ctx, rc.Conn)
+	client.AllowMissingFileDescriptors()
 
 	services, err := client.ListServices()
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -173,7 +173,7 @@ github.com/grafana/sobek/ftoa/internal/fast
 github.com/grafana/sobek/parser
 github.com/grafana/sobek/token
 github.com/grafana/sobek/unistring
-# github.com/grafana/xk6-browser v1.6.1-0.20240701105714-29f6ef3049fe
+# github.com/grafana/xk6-browser v1.7.0
 ## explicit; go 1.20
 github.com/grafana/xk6-browser/browser
 github.com/grafana/xk6-browser/chromium


### PR DESCRIPTION
## What?
Add call to `AllowMissingFileDescriptors` in `lib/netext/grpcext/reflect.go`. 


<!-- A short (or detailed) description of what this PR does. -->

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->
When this option is enabled, the reflection service will tolerate the absence of certain file descriptors. This means that if a file descriptor is missing, the reflection service will still attempt to provide information about available services and methods, albeit potentially incomplete.

For context as to why we want this fix, we are experiencing similar issues to the issues reported by grpcurl in this issue: https://github.com/fullstorydev/grpcurl/pull/453, and noted after grpcurl 1.9.0 was released with this fix in place the following type of errors were resolved:

```
Failed to list methods for service "xxx.yyy": Symbol not found: xxx.yyy
caused by: File not found: openapi/v3/annotations.proto
```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
